### PR TITLE
Fix cabal: benchmark for benchmarks instead of executable

### DIFF
--- a/ambiata-anemone.cabal
+++ b/ambiata-anemone.cabal
@@ -81,7 +81,8 @@ test-suite test
                      , bytestring                      == 0.10.*
 
 
-executable bench
+benchmark bench
+  type:                exitcode-stdio-1.0
 
   main-is:             bench.hs
 


### PR DESCRIPTION
plz
