### PR TITLE
Safer reading / writing of vints, also support for single vints

### DIFF
--- a/cbits/anemone_vint.h
+++ b/cbits/anemone_vint.h
@@ -6,7 +6,22 @@
 #define ANEMONE_MAX_VINT_SIZE 9
 
 //
-// Packs an array of Hadoop-style zero-compressed integers.
+// Writes a single Hadoop-style zero-compressed integer.
+//
+// x:
+//   an integer to pack
+//
+// pout:
+//   pointer to buffer large enough to hold a packed integer (ANEMONE_MAX_VINT_SIZE)
+//
+// *returns*
+//   pointer to the part of the 'pout' buffer which is unused
+//   (number of bytes used = return value - pout)
+//
+uint8_t* anemone_write_vint (int64_t x, uint8_t *pout);
+
+//
+// Writes an array of Hadoop-style zero-compressed integers.
 //
 // n:
 //   number of integers to pack
@@ -18,21 +33,39 @@
 //   pointer to buffer large enough to hold packed integers (n * ANEMONE_MAX_VINT_SIZE)
 //
 // *returns*
-//   number of bytes used to pack the integers
+//   pointer to the part of the 'pout' buffer which is unused
+//   (number of bytes used = return value - pout)
 //
-size_t anemone_pack_vint (int64_t n, const int64_t *p, uint8_t *pout);
+uint8_t* anemone_write_vint_array (int64_t n, const int64_t *p, uint8_t *pout);
 
 //
-// Unpacks an array of Hadoop-style zero-compressed integers.
+// Reads a single Hadoop-style zero-compressed integer.
 //
-// n:
-//   number of integers to unpack
-//
-// p:
-//   pointer to start of packed integers
+// pp:
+//   pointer to start of buffer
 //
 // pe:
-//   pointer to end of packed integers
+//   pointer to end of buffer
+//
+// pout:
+//   pointer to an integer for output
+//
+// *returns*
+//   zero on success, non-zero if the input was corrupt.
+//
+error_t anemone_read_vint (const uint8_t **pp, const uint8_t *pe, int64_t *pout);
+
+//
+// Reads an array of Hadoop-style zero-compressed integers.
+//
+// pp:
+//   pointer to start of buffer
+//
+// pe:
+//   pointer to end of buffer
+//
+// n:
+//   number of integers to read
 //
 // pout:
 //   pointer to buffer large enough to hold unpacked integers.
@@ -40,6 +73,6 @@ size_t anemone_pack_vint (int64_t n, const int64_t *p, uint8_t *pout);
 // *returns*
 //   zero on success, non-zero if the input was corrupt.
 //
-error_t anemone_unpack_vint (int64_t n, const uint8_t *p, const uint8_t *pe, int64_t *pout);
+error_t anemone_read_vint_array (const uint8_t **pp, const uint8_t *pe, int64_t n, int64_t *pout);
 
 #endif//__ANEMONE_VINT_H

--- a/src/Anemone/Foreign/VInt.hs
+++ b/src/Anemone/Foreign/VInt.hs
@@ -1,12 +1,21 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 module Anemone.Foreign.VInt (
-    packVInt
-  , unpackVInt
+    bVInt
+
+  , encodeVInt
+  , encodeVIntArray
+
+  , decodeVInt
+  , decodeVIntArray
   ) where
 
 import           Anemone.Foreign.Data
 
+import           Data.ByteString.Builder (Builder)
+import qualified Data.ByteString.Builder.Prim as Builder
+import qualified Data.ByteString.Builder.Prim.Internal as Builder
 import           Data.ByteString.Internal (ByteString(..))
 import qualified Data.ByteString.Internal as B
 import qualified Data.Vector.Storable as Storable
@@ -14,7 +23,9 @@ import           Data.Word (Word8)
 
 import           Foreign.C.Types (CInt(..))
 import           Foreign.ForeignPtr (withForeignPtr)
-import           Foreign.Ptr (Ptr, plusPtr)
+import           Foreign.Marshal.Alloc (alloca)
+import           Foreign.Ptr (Ptr, plusPtr, minusPtr)
+import           Foreign.Storable (peek, poke)
 
 import           GHC.ForeignPtr (mallocPlainForeignPtrBytes)
 
@@ -28,8 +39,20 @@ maxVIntSize :: Int
 maxVIntSize =
   9
 
-packVInt :: Storable.Vector Int64 -> ByteString
-packVInt xs =
+bVInt :: Int64 -> Builder
+bVInt =
+  Builder.primBounded $
+    Builder.boudedPrim maxVIntSize c_write_vint
+
+encodeVInt :: Int64 -> ByteString
+encodeVInt x =
+  unsafePerformIO $
+    B.createUptoN maxVIntSize $ \ptr_out -> do
+      !ptr_end <- c_write_vint x ptr_out
+      pure $! ptr_end `minusPtr` ptr_out
+
+encodeVIntArray :: Storable.Vector Int64 -> ByteString
+encodeVIntArray xs =
   let
     n =
       Storable.length xs
@@ -42,44 +65,105 @@ packVInt xs =
   in
     unsafePerformIO $
       withForeignPtr fp_in $ \ptr_in ->
-      B.createUptoN maxSize $ \ptr_out ->
-        fromIntegral <$> c_pack_vint (fromIntegral n) ptr_in ptr_out
+      B.createUptoN maxSize $ \ptr_out -> do
+        !ptr_end <- c_write_vint_array (fromIntegral n) ptr_in ptr_out
+        pure $! ptr_end `minusPtr` ptr_out
 
-unpackVInt :: Int -> ByteString -> Maybe (Storable.Vector Int64)
-unpackVInt n (PS fp_in off_in len_in) =
+decodeVInt :: ByteString -> Maybe (Int64, ByteString)
+decodeVInt (PS fp_in off_in len_in) =
+  unsafePerformIO $ do
+    (code, result, used) <-
+      withForeignPtr fp_in $ \ptr_in0 ->
+      alloca $ \pptr_in ->
+      alloca $ \ptr_out -> do
+        let
+          !ptr_in1 =
+            ptr_in0 `plusPtr` off_in
+
+        poke pptr_in ptr_in1
+
+        !code <-
+          c_read_vint
+            pptr_in
+            (ptr_in1 `plusPtr` len_in)
+            ptr_out
+
+        ptr_in2 <- peek pptr_in
+        out <- peek ptr_out
+
+        pure $! (code, out, ptr_in2 `minusPtr` ptr_in1)
+
+    case code of
+      0 ->
+        pure . Just $
+          ( result
+          , PS fp_in (off_in + used) (len_in - used)
+          )
+      _ ->
+        pure Nothing
+
+decodeVIntArray :: Int -> ByteString -> Maybe (Storable.Vector Int64, ByteString)
+decodeVIntArray n (PS fp_in off_in len_in) =
   if n < 0 then
     Nothing
   else
     unsafePerformIO $ do
       fp_out <- mallocPlainForeignPtrBytes (n * 8)
 
-      code <-
+      (code, used) <-
         withForeignPtr fp_out $ \ptr_out ->
-        withForeignPtr fp_in $ \ptr_in ->
-          c_unpack_vint
-            (fromIntegral n)
-            (ptr_in `plusPtr` off_in)
-            (ptr_in `plusPtr` off_in `plusPtr` len_in)
-            ptr_out
+        withForeignPtr fp_in $ \ptr_in0 ->
+        alloca $ \pptr_in -> do
+          let
+            !ptr_in1 =
+              ptr_in0 `plusPtr` off_in
+
+          poke pptr_in ptr_in1
+
+          !code <-
+            c_read_vint_array
+              pptr_in
+              (ptr_in1 `plusPtr` len_in)
+              (fromIntegral n)
+              ptr_out
+
+          ptr_in2 <- peek pptr_in
+
+          pure $! (code, ptr_in2 `minusPtr` ptr_in1)
 
       case code of
         0 ->
           pure . Just $
-            Storable.unsafeFromForeignPtr0 fp_out n
+            ( Storable.unsafeFromForeignPtr0 fp_out n
+            , PS fp_in (off_in + used) (len_in - used)
+            )
         _ ->
           pure Nothing
 
-foreign import ccall unsafe "anemone_pack_vint"
-  c_pack_vint ::
+foreign import ccall unsafe "anemone_write_vint"
+  c_write_vint ::
+    Int64 ->
+    Ptr Word8 ->
+    IO (Ptr Word8)
+
+foreign import ccall unsafe "anemone_write_vint_array"
+  c_write_vint_array ::
     Int64 ->
     Ptr Int64 ->
     Ptr Word8 ->
-    IO CSize
+    IO (Ptr Word8)
 
-foreign import ccall unsafe "anemone_unpack_vint"
-  c_unpack_vint ::
+foreign import ccall unsafe "anemone_read_vint"
+  c_read_vint ::
+    Ptr (Ptr Word8) ->
+    Ptr Word8 ->
+    Ptr Int64 ->
+    IO CError
+
+foreign import ccall unsafe "anemone_read_vint_array"
+  c_read_vint_array ::
+    Ptr (Ptr Word8) ->
+    Ptr Word8 ->
     Int64 ->
-    Ptr Word8 ->
-    Ptr Word8 ->
     Ptr Int64 ->
     IO CError


### PR DESCRIPTION
/jury assign @amosr @tranma

Just a bit of a clean up, also reading is safer as it now checks against the `p` / `pe` pointers as it progresses.
