### PR TITLE
Relax constraints on file-embed dependency

### DIFF
--- a/ambiata-anemone.cabal
+++ b/ambiata-anemone.cabal
@@ -22,7 +22,7 @@ library
                        base                            >= 3          && < 5
                      , ambiata-p
                      , bytestring                      == 0.10.*
-                     , file-embed                      == 0.0.9
+                     , file-embed                      >= 0.0.8      && < 0.0.10
                      , filepath                        >= 1.3        && < 1.5
                      , text                            == 1.2.*
                      , thyme                           >= 0.3        && < 0.4


### PR DESCRIPTION
The old constraint was `== 0.0.9` but I need this to work with stuff
that has `file-embed == 0.0.8`. Tested this project with version
0.0.8 and it was fine so accept both versions. Would have set an
even laxer upper bound if it wasn't `0.0.*`.

! @amosr @jystic 