### PR TITLE
Fix buffer alignment issues

### DIFF
--- a/csrc/anemone_mempool.c
+++ b/csrc/anemone_mempool.c
@@ -1,11 +1,12 @@
 #include "anemone_mempool.h"
 #include <string.h>
+#include <malloc.h>
 
 // Allocate a new block with given predecessor 
 ANEMONE_STATIC
 anemone_block_t * anemone_block_create (anemone_block_t *prev, size_t num_bytes)
 {
-  void     *ptr = malloc (num_bytes);
+  void     *ptr = memalign(ANEMONE_ALIGNMENT, num_bytes);
   anemone_block_t  src = { ptr, prev };
 
   anemone_block_t *dst = malloc (sizeof (anemone_block_t));

--- a/csrc/anemone_mempool.c
+++ b/csrc/anemone_mempool.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <malloc.h>
 
-// Allocate a new block with given predecessor 
+// Allocate a new block with given predecessor
 ANEMONE_STATIC
 anemone_block_t * anemone_block_create (anemone_block_t *prev, size_t num_bytes)
 {
@@ -139,3 +139,8 @@ int64_t anemone_mempool_total_alloc_size (anemone_mempool_t *pool)
   return pool->total_alloc_size;
 }
 
+// Return true if the pointer points to an aligned address.
+bool_t anemone_is_pointer_aligned (const void *ptr)
+{
+  return (((uint64_t) ptr) % ANEMONE_ALIGNMENT) == 0 ;
+}

--- a/csrc/anemone_mempool.h
+++ b/csrc/anemone_mempool.h
@@ -94,3 +94,5 @@ void * anemone_mempool_calloc (anemone_mempool_t *pool, size_t num_items, size_t
 // Get the total alloc size - this is only necessary for calling from Haskell
 int64_t anemone_mempool_total_alloc_size (anemone_mempool_t *pool);
 
+// Return true if the pointer points to an aligned address.
+bool_t anemone_is_pointer_aligned (const void *ptr);

--- a/src/Anemone/Foreign/Data.hs
+++ b/src/Anemone/Foreign/Data.hs
@@ -3,6 +3,7 @@
 module Anemone.Foreign.Data (
     CBool(..)
   , CError(..)
+  , fromCBool
 
   -- ** re-exports to avoid 'Unacceptable result type in foreign declaration'
   , CInt(..)
@@ -23,3 +24,6 @@ newtype CBool =
 newtype CError =
   CError CInt
   deriving (Eq, Ord, Read, Show, Enum, Bounded, Integral, Num, Real, FiniteBits, Bits, Storable)
+
+fromCBool :: CBool -> Bool
+fromCBool (CBool i) = i /= 0

--- a/src/Anemone/Foreign/Mempool.hs
+++ b/src/Anemone/Foreign/Mempool.hs
@@ -10,9 +10,12 @@ module Anemone.Foreign.Mempool (
   , callocBytes
   , free
   , totalAllocSize
+  , isPointerAligned
   ) where
 
-import           Foreign.C.Types ( CSize(..) )
+import           Anemone.Foreign.Data ( CBool(..) )
+
+import           Foreign.C.Types ( CInt (..), CSize(..) )
 import           Foreign.Ptr ( Ptr )
 import           Foreign.Storable ( Storable(..) )
 
@@ -47,6 +50,9 @@ foreign import ccall unsafe "anemone_mempool_free"
 foreign import ccall unsafe "anemone_mempool_total_alloc_size"
   totalAllocSize :: Mempool -> IO Int64
 
+foreign import ccall unsafe "anemone_is_pointer_aligned"
+  isPointerAligned :: Ptr Void -> IO CBool
+
 alloc :: forall a. Storable a => Mempool -> IO (Ptr a)
 alloc mp =
   allocBytes mp (fromIntegral $ sizeOf (Savage.undefined :: a))
@@ -54,4 +60,3 @@ alloc mp =
 calloc :: forall a. Storable a => Mempool -> CSize -> IO (Ptr a)
 calloc mp i =
   callocBytes mp i (fromIntegral $ sizeOf (Savage.undefined :: a))
-


### PR DESCRIPTION
When compiling with very recent GCC (version 6.3.0 20170124) from Debian
was suffering from segfaults due to code with SSE vector instructions
attempting to do un-aligned accesses of `int64_t` data.

The solution was two fold:

a) Use `memalign` instead of `malloc`.
b) Make sure all allocations allocate a multiple of 16 bytes.

I don't want to merge this until I have a QC property. I mainly want to make sure that Ancient GCC compiles this correctly.

! @jystic @tranma @amosr 
/jury approved @amosr @jystic