### PR TITLE
anemone_string_to_i64: Fix UBSAN warning

### DIFF
--- a/csrc/anemone_atoi.c
+++ b/csrc/anemone_atoi.c
@@ -26,32 +26,31 @@ error_t anemone_string_to_i64 (char **pp, char *pe, int64_t *output_ptr)
     if (digits == 0)
         return 1;
 
-    int64_t value = 0;
+    uint64_t value = 0;
 
     /* handle up to 19 digits, assume we're 64-bit */
     switch (digits) {
-        case 19:  value += (p[digits-19] - '0') * 1000000000000000000LL;
-        case 18:  value += (p[digits-18] - '0') * 100000000000000000LL;
-        case 17:  value += (p[digits-17] - '0') * 10000000000000000LL;
-        case 16:  value += (p[digits-16] - '0') * 1000000000000000LL;
-        case 15:  value += (p[digits-15] - '0') * 100000000000000LL;
-        case 14:  value += (p[digits-14] - '0') * 10000000000000LL;
-        case 13:  value += (p[digits-13] - '0') * 1000000000000LL;
-        case 12:  value += (p[digits-12] - '0') * 100000000000LL;
-        case 11:  value += (p[digits-11] - '0') * 10000000000LL;
-        case 10:  value += (p[digits-10] - '0') * 1000000000LL;
-        case  9:  value += (p[digits- 9] - '0') * 100000000LL;
-        case  8:  value += (p[digits- 8] - '0') * 10000000LL;
-        case  7:  value += (p[digits- 7] - '0') * 1000000LL;
-        case  6:  value += (p[digits- 6] - '0') * 100000LL;
-        case  5:  value += (p[digits- 5] - '0') * 10000LL;
-        case  4:  value += (p[digits- 4] - '0') * 1000LL;
-        case  3:  value += (p[digits- 3] - '0') * 100LL;
-        case  2:  value += (p[digits- 2] - '0') * 10LL;
+        case 19:  value += (p[digits-19] - '0') * 1000000000000000000LLU;
+        case 18:  value += (p[digits-18] - '0') * 100000000000000000LLU;
+        case 17:  value += (p[digits-17] - '0') * 10000000000000000LLU;
+        case 16:  value += (p[digits-16] - '0') * 1000000000000000LLU;
+        case 15:  value += (p[digits-15] - '0') * 100000000000000LLU;
+        case 14:  value += (p[digits-14] - '0') * 10000000000000LLU;
+        case 13:  value += (p[digits-13] - '0') * 1000000000000LLU;
+        case 12:  value += (p[digits-12] - '0') * 100000000000LLU;
+        case 11:  value += (p[digits-11] - '0') * 10000000000LLU;
+        case 10:  value += (p[digits-10] - '0') * 1000000000LLU;
+        case  9:  value += (p[digits- 9] - '0') * 100000000LLU;
+        case  8:  value += (p[digits- 8] - '0') * 10000000LLU;
+        case  7:  value += (p[digits- 7] - '0') * 1000000LLU;
+        case  6:  value += (p[digits- 6] - '0') * 100000LLU;
+        case  5:  value += (p[digits- 5] - '0') * 10000LLU;
+        case  4:  value += (p[digits- 4] - '0') * 1000LLU;
+        case  3:  value += (p[digits- 3] - '0') * 100LLU;
+        case  2:  value += (p[digits- 2] - '0') * 10LLU;
         case  1:  value += (p[digits- 1] - '0');
         /* ^ fall through */
-            value *= sign;
-            *output_ptr = value;
+            *output_ptr = ((int64_t) value) * sign;
             *pp += digits + sign_size;
             return 0;
 


### PR DESCRIPTION
When `value` was signed some of the operations caused an overflow into the sign bit. By making it unsigned and then casting it to signed, the warning goes away.

I wonder if we need to be concerned about `value` overflowing? Should an error be returned?

! @amosr @jystic 